### PR TITLE
Fix Rendering for Markup Closing Tags

### DIFF
--- a/High/KittyHigh.cs
+++ b/High/KittyHigh.cs
@@ -413,9 +413,17 @@ namespace Kitty {
                             }
                         }
                     }
+                    else if (word == "" && intag && ch == '/' && lines[i][p + 1] == '>')
+                    {
+                        p += 1;
+                        word = "/>";
+                        intag = false;
+                        showword();
+                        word = "";
+                    }
                     else
                     {
-                        if (ch == '>' || ch == '/')
+                        if (ch == '>')
                             intag = false;
                         if (word != "") showword(); word = $"{ch}"; showword(); word = "";
                     }


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/27819706/95640645-ff0b3580-0a9d-11eb-8958-4a709379aa80.png)

After:
![grafik](https://user-images.githubusercontent.com/27819706/95640660-092d3400-0a9e-11eb-9e26-0e020afde6bb.png)
