### PR TITLE
Implement multiple ways to start strings

### DIFF
--- a/High/KittyHigh.cs
+++ b/High/KittyHigh.cs
@@ -65,6 +65,18 @@ namespace Kitty {
     }
 
     abstract class KittyHigh {
+        protected struct StringDelimiterPair
+        {
+            public string Start;
+            public string End;
+
+            public StringDelimiterPair(string start, string end)
+            {
+                Start = start;
+                End = end;
+            }
+        }
+
         static readonly public SortedDictionary<string, KittyHigh> Langs = new SortedDictionary<string, KittyHigh>();
         static KittyOutput _ko = null;
         static public int NumLines => Console.WindowHeight;

--- a/High/KittyHigh.cs
+++ b/High/KittyHigh.cs
@@ -287,6 +287,8 @@ namespace Kitty {
     {
         protected string stringstart = "\"";
         protected string stringend = "\"";
+        protected string astringstart = "'";
+        protected string astringend = "'";
         protected bool mulcomment = true;
         protected string mulcommentstart = "<!--";
         protected string mulcommentend = "-->";
@@ -320,20 +322,25 @@ namespace Kitty {
                 var singstring = false;
                 var stringescape = false;
                 bool wassingstring;
-
+                bool wassingstring2;
+                bool secondstring = false;
                 for (int p = 0; p < lines[i].Length; p++)
                 {
                     var ch = lines[i][p];
 
                     wassingstring = singstring;
+                    wassingstring2 = secondstring;
                     singstring = singstring || (p < lines[i].Length - 1 && lines[i].Substring(p, stringstart.Length) == stringstart);
                     mulcomm = mulcomm || (p < lines[i].Length - 3 && lines[i].Substring(p, mulcommentstart.Length) == mulcommentstart && !singstring && mulcomment);
-                    if (singstring)
+                    secondstring = secondstring || (p < lines[i].Length - 1 && lines[i].Substring(p, astringstart.Length) == astringstart && (!mulcomm));
+                    if (singstring || secondstring)
                     {
                         Console.ForegroundColor = KittyColors.String;
                         Console.Write($"{ch}");
                         if (wassingstring && p < lines[i].Length && lines[i].Substring(p, stringend.Length) == stringend && !stringescape)
                             singstring = false;
+                        else if (wassingstring2 && p < lines[i].Length && lines[i].Substring(p, astringend.Length) == astringend && !stringescape)
+                            secondstring = false;
                         else
                             stringescape = ch == escape && !stringescape;
                     }

--- a/High/KittyHigh.cs
+++ b/High/KittyHigh.cs
@@ -219,12 +219,15 @@ namespace Kitty {
                 word = "";
                 var singcomm = false;
                 var singstring = false;
+                var secondstring = false;
                 var stringescape = false;
                 var wassingstring = false;
+                var wassingstring2 = false;
                 for (int p = 0; p < lines[i].Length; p++) {
                     var ch = lines[i][p];
                     // Console.WriteLine($"DEBUG! {lines[i].Substring(p, singcomment.Length)} {singcomment}");
                     wassingstring = singstring;
+                    wassingstring2 = secondstring;
                     singcomm = singcomm || (p < lines[i].Length - 1 && lines[i].Substring(p, singcomment.Length) == singcomment && (!singstring) && (!mulcomm) && supcom);
                     try {
                         mulcomm = mulcomm || (p < lines[i].Length - 1 && lines[i].Substring(p, Math.Min(lines[i].Length-p, mulcommentstart.Length)) == mulcommentstart && (!singstring) & (!singcomm) && mulcomment);
@@ -234,11 +237,14 @@ namespace Kitty {
                         //mulcomm = false;
                     }
                     singstring = singstring || (p < lines[i].Length - 1 && lines[i].Substring(p, stringstart.Length) == stringstart && (!singcomm) && (!mulcomm));
-                    if (singstring) {
+                    secondstring = secondstring || (p < lines[i].Length - 1 && lines[i].Substring(p, astringstart.Length) == astringstart && (!singcomm) && (!mulcomm));
+                    if (singstring || secondstring) {
                         Console.ForegroundColor = KittyColors.String;
                         Console.Write($"{ch}");
                         if (wassingstring && p < lines[i].Length && lines[i].Substring(p, stringend.Length) == stringend && !stringescape)
                             singstring = false;
+                        else if (wassingstring && p < lines[i].Length && lines[i].Substring(p, astringend.Length) == astringend && !stringescape)
+                            secondstring = false;
                         else
                             stringescape = ch == escape && !stringescape;
                     } else if (mulcomm) {

--- a/High/KittyHigh.cs
+++ b/High/KittyHigh.cs
@@ -221,13 +221,11 @@ namespace Kitty {
                 var singstring = false;
                 var secondstring = false;
                 var stringescape = false;
-                var wassingstring = false;
-                var wassingstring2 = false;
                 for (int p = 0; p < lines[i].Length; p++) {
                     var ch = lines[i][p];
                     // Console.WriteLine($"DEBUG! {lines[i].Substring(p, singcomment.Length)} {singcomment}");
-                    wassingstring = singstring;
-                    wassingstring2 = secondstring;
+                    bool wassingstring = singstring;
+                    bool wassingstring2 = secondstring;
                     singcomm = singcomm || (p < lines[i].Length - 1 && lines[i].Substring(p, singcomment.Length) == singcomment && (!singstring) && (!mulcomm) && supcom);
                     try {
                         mulcomm = mulcomm || (p < lines[i].Length - 1 && lines[i].Substring(p, Math.Min(lines[i].Length-p, mulcommentstart.Length)) == mulcommentstart && (!singstring) & (!singcomm) && mulcomment);
@@ -243,7 +241,7 @@ namespace Kitty {
                         Console.Write($"{ch}");
                         if (wassingstring && p < lines[i].Length && lines[i].Substring(p, stringend.Length) == stringend && !stringescape)
                             singstring = false;
-                        else if (wassingstring && p < lines[i].Length && lines[i].Substring(p, astringend.Length) == astringend && !stringescape)
+                        else if (wassingstring2 && p < lines[i].Length && lines[i].Substring(p, astringend.Length) == astringend && !stringescape)
                             secondstring = false;
                         else
                             stringescape = ch == escape && !stringescape;

--- a/High/KittyHighJavaScript.cs
+++ b/High/KittyHighJavaScript.cs
@@ -92,6 +92,8 @@ namespace Kitty {
             Language = "JavaScript";
             Langs["js"] = this;
             new KittyHighJSON();
+            StringDelimiters.Add(new StringDelimiterPair("\"", "\""));
+            StringDelimiters.Add(new StringDelimiterPair("'", "'"));
         }
     }
 

--- a/High/KittyHighPython.cs
+++ b/High/KittyHighPython.cs
@@ -59,6 +59,8 @@ namespace Kitty {
             singcomment = "#";
             Language = "Python";
             Langs["py"] = this;
+            StringDelimiters.Add(new StringDelimiterPair("\"", "\""));
+            StringDelimiters.Add(new StringDelimiterPair("'", "'"));
         }
     }
 }


### PR DESCRIPTION
Closes #7 and closes #5 
![grafik](https://user-images.githubusercontent.com/27819706/96048793-6139b100-0e77-11eb-822b-36d2ce9d9c5d.png)

I consider changing converting
```c#
protected string stringstart = "\"";
protected string stringend = "\"";
&
protected string astringstart = "'";
protected string astringend = "'";
```
to something like an string array or list 
```c#
protected string[] stringStarts = ...;
protected string[] stringEnd = ...;
```

This would be more in line with how I will probably handle the markdown parsing. It would also increase the maintainability of the code, since nobody would have to add another case to the parser if there would be the need for a third string start / end.

EDIT: Just thinking about it, I realized that this is not possible since there is no way to know which start matches which end. Maybe a list of structs `stringDelimiterPair` ? 😋 

EDIT2: I will implement #5 with this PR too

I will mark the PR as draft until this is done