### PR TITLE
Reset color after finishing

### DIFF
--- a/High/KittyHigh.cs
+++ b/High/KittyHigh.cs
@@ -39,6 +39,12 @@ namespace Kitty {
     }
 
     abstract class KittyOutput {
+
+        ~KittyOutput()
+        {
+            Console.ResetColor();
+        }
+
         abstract public void Write(string a);
         abstract public void WriteLine(string a);
         public void WriteLine() => WriteLine("");


### PR DESCRIPTION
This is a fix for a bug that I encountered using the new terminal and the default CMD.

Before:

![grafik](https://user-images.githubusercontent.com/27819706/96353388-ba9a1e00-10cb-11eb-98fe-2e32065b57d0.png)

After:

![grafik](https://user-images.githubusercontent.com/27819706/96353382-ab1ad500-10cb-11eb-90ab-cd4eed5e08c2.png)
